### PR TITLE
content: expand all 16 stub pages to full documentation

### DIFF
--- a/src/content/docs/building/overview.md
+++ b/src/content/docs/building/overview.md
@@ -1,28 +1,78 @@
 ---
-title: Building a Quad
-description: Step-by-step guide to assembling your FPV quad from parts.
+title: Building Your Quad
+description: Step-by-step guide to assembling an FPV quadcopter from parts.
 ---
 
-Building your own quad is one of the most rewarding parts of the hobby. You'll understand every component, know how to repair it in the field, and have a machine tuned exactly to your preferences.
-
-## Build Order
-
-This guide walks through assembly in a logical order:
-
-1. **[Sanding the Carbon Fiber](/building/sanding-carbon-fiber/)** — Prep the frame
-2. **[Battery Strap and Protector](/building/battery-strap/)** — Secure your power
-3. **[Power Distribution and Battery Lead](/building/power-distribution/)** — Wire up power
-4. **[Speed Controllers](/building/speed-controllers/)** — Mount and wire ESCs
-5. **[Motors](/building/motors/)** — Attach and wire motors
-6. **[Flight Controller](/building/flight-controller/)** — Install the brain
-7. **[Receiver](/building/receiver/)** — Add radio control
-8. **[Video Transmitter](/building/vtx/)** — Wire up video
-9. **[Camera](/building/camera/)** — Mount the FPV camera
+Building your own quad gives you a deeper understanding of how everything works, the ability to repair anything that breaks, and a machine tuned exactly to your preferences. It takes a few hours for a first build and gets faster with experience.
 
 ## Before You Start
 
-- Read the documentation for every component.
-- Have your [tools](/tools/overview/) ready.
-- Work in a clean, well-lit area.
-- Take photos as you go — helps with troubleshooting later.
-- Don't rush. A clean build is a reliable build.
+### Tools You'll Need
+At minimum:
+- **Soldering iron** (temperature-controlled, 60W+) and solder (60/40 or 63/37 rosin core, 0.8mm)
+- **Hex drivers**: 2.0mm (most common), 1.5mm, and 2.5mm
+- **Wire strippers** and flush cutters
+- **Multimeter** for checking continuity and voltage
+- **Helping hands or PCB holder** for soldering
+- **Heat shrink tubing** in various sizes
+- **Double-sided foam tape** or VHB tape
+
+See the [tools guide](/tools/overview/) and [accessories](/tools/accessories/) for detailed recommendations.
+
+### Skills
+The main skill you need is [soldering](/skills/soldering/). Every connection on your quad is soldered. Bad solder joints cause intermittent failures that are maddening to diagnose. If you've never soldered, practice on scrap wire and old circuit boards before touching your flight controller.
+
+## Build Order
+
+While every build is slightly different, this order works for most 5" quad builds:
+
+### 1. [Frame Assembly](/frame/overview/)
+Assemble the frame first. Install standoffs, check that all hardware fits, and familiarize yourself with the layout. Don't fully tighten bolts yet since you may need to adjust spacing for your electronics stack.
+
+### 2. [Motors](/building/motors/)
+Mount motors to frame arms using the included bolts. Route motor wires through or along the arms. Leave enough wire length to reach the ESC, but not so much that excess wire creates a messy build.
+
+### 3. [Speed Controllers (ESC)](/building/speed-controllers/)
+If using a 4-in-1 ESC, mount it as the bottom board of your stack. Solder motor wires to the ESC pads. If using individual ESCs, mount one per arm and wire them to both the motor and the power distribution.
+
+### 4. [Flight Controller](/building/flight-controller/)
+Mount the FC above the ESC in the stack. Connect the ESC signal and telemetry wires. Solder or plug in your receiver. This is the most wiring-dense step, so take your time and double-check pin assignments against the FC's wiring diagram.
+
+### 5. [Power Distribution](/building/power-distribution/)
+Wire the battery lead to the ESC or PDB (power distribution board). Verify polarity with a multimeter before plugging in a battery. A reversed polarity connection will instantly destroy your electronics.
+
+### 6. [Receiver](/building/receiver/)
+Mount and solder or plug in your radio receiver. Bind it to your transmitter. Configure the UART and protocol in Betaflight. Test that all channels respond correctly.
+
+### 7. [FPV Camera](/building/camera/)
+Mount the camera in the frame's camera mount. Adjust the angle. Wire power and video signal to the FC or directly to the VTX.
+
+### 8. [Video Transmitter (VTX)](/building/vtx/)
+Mount and wire the VTX. Connect the antenna. Route the antenna so it points upward and away from carbon fiber (which blocks RF signal).
+
+## First Power-Up
+
+Before the first battery plug:
+1. **Inspect every solder joint** with a magnifier. Look for cold joints, bridges, and loose connections.
+2. **Check for shorts** with a multimeter in continuity mode across the battery pad positive and negative. If it beeps, you have a short. Find and fix it before applying power.
+3. **Use a smoke stopper** if you have one. This current-limiting device prevents damage if there's a wiring mistake.
+4. **Remove propellers.** Never have props on during bench testing.
+
+Then plug in the battery and verify:
+- FC powers up and connects to Betaflight Configurator
+- All motors spin in the correct direction (adjust in BLHeli/AM32 configurator if needed)
+- Receiver is bound and all channels move correctly in the Receiver tab
+- VTX outputs video to your goggles
+- OSD displays correctly
+
+## Common First-Build Mistakes
+
+- **Skipping the smoke stopper**: One reversed wire destroys a $40 flight controller instantly
+- **Forgetting to check motor direction**: Two motors should spin clockwise, two counter-clockwise. Getting this wrong means the quad flips on takeoff
+- **Poor antenna placement**: VTX antenna buried inside the frame or touching carbon fiber kills range
+- **Not securing the battery lead**: The battery connector takes abuse on hard landings. Zip-tie or velcro the XT60 so it can't yank free mid-flight
+- **Over-complicated wiring**: Route wires cleanly and keep them short. Long dangling wires snag on props
+
+## Time Estimate
+
+A first build typically takes 3-6 hours. Experienced builders can assemble a quad in 1-2 hours. Don't rush your first build. Clean work now saves hours of troubleshooting later.

--- a/src/content/docs/control/overview.md
+++ b/src/content/docs/control/overview.md
@@ -1,28 +1,68 @@
 ---
-title: Control Systems
-description: How you control your quad — radios, receivers, and protocols.
+title: Control System
+description: Radio transmitters, receivers, and the protocols that connect pilot to quad.
 ---
 
-The control system is how your inputs on the ground translate to movement in the air.
+The control system is your link to the quad. A radio transmitter in your hands sends stick inputs to a receiver on the drone, which passes those commands to the flight controller. Every millisecond of latency, every dropped packet, and every range limitation in this chain directly affects how your quad responds.
 
-## The Chain
+## Components
 
-```
-Your Hands → Radio Transmitter (TX) → Radio Signal → Receiver (RX) → Flight Controller → ESCs → Motors
-```
+### [Radio Transmitter (TX)](/control/radio-transmitter/)
+The controller you hold. Modern FPV transmitters use hall-effect gimbals (no potentiometer wear), run EdgeTX or OpenTX firmware, and support multiple RF protocols through external or internal modules. Common form factors:
+- **Full-size**: RadioMaster TX16S, Jumper T-Pro, TBS Tango 2
+- **Compact/gamepad**: RadioMaster Pocket, BetaFPV LiteRadio 3
 
-## Key Components
+Most pilots choose based on ergonomics and whether they prefer a traditional radio grip or a gamepad style.
 
-- **Radio Transmitter (TX)** — The controller you hold. Sends stick inputs wirelessly.
-- **Receiver (RX)** — Mounted on the quad. Receives commands from your TX.
-- **Protocols** — The language TX and RX speak. SBUS, CRSF, etc.
-- **Telemetry** — Data sent back from the quad to your TX (battery voltage, RSSI, GPS).
-- **Failsafe** — What happens when the radio link is lost.
+### [Receiver (RX)](/control/receiver/)
+A small module on the quad that receives commands from your transmitter. Receivers are protocol-specific, meaning your RX must match your TX's RF protocol. Modern receivers are tiny (some ELRS receivers weigh under 1 gram) and mount directly to the flight controller via UART.
 
-## Sections
+### [ExpressLRS (ELRS)](/control/elrs/)
+The dominant open-source control link protocol. ELRS operates on 2.4GHz or 900MHz and offers extremely low latency, long range, and high update rates. It has largely replaced proprietary systems like FrSky and Crossfire for new builds due to its performance, open development, and low cost.
 
-- [Radio Transmitter](/control/radio-transmitter/)
-- [Protocols](/control/protocols/)
-- [Telemetry](/control/telemetry/)
-- [Receiver](/control/receiver/)
-- [Failsafe](/control/failsafe/)
+## Protocols
+
+The [protocols page](/control/protocols/) covers the technical details, but here's the practical summary:
+
+| Protocol | Frequency | Range | Latency | Status |
+|----------|-----------|-------|---------|--------|
+| **ELRS 2.4GHz** | 2.4GHz | 10-30km+ | < 5ms | Current standard |
+| **ELRS 900MHz** | 900MHz | 40-100km+ | < 5ms | Long range |
+| **TBS Crossfire** | 900MHz | 40km+ | ~7ms | Established, proprietary |
+| **TBS Tracer** | 2.4GHz | 5km+ | ~4ms | Proprietary alternative |
+| **FrSky** | 2.4GHz | 1-2km | ~15-20ms | Legacy, declining |
+| **Flysky** | 2.4GHz | 500m-1km | ~20ms | Budget, limited |
+
+For new builds, **ELRS 2.4GHz** is the clear recommendation. It's fast, reliable, cheap ($10-15 for a receiver), and the community keeps improving it.
+
+## Key Concepts
+
+### Update Rate
+How many times per second the transmitter sends a command packet to the receiver. Higher rates mean more responsive control:
+- **50Hz**: Old standard. Noticeable input lag.
+- **150Hz**: Minimum for smooth FPV flying.
+- **250-500Hz**: Standard for ELRS and Crossfire. Good for most pilots.
+- **1000Hz**: Maximum ELRS rate at close range. Competitive racers may notice the difference.
+
+Higher update rates reduce range because the receiver has less time to listen for each packet. Most pilots run 250Hz or 500Hz as a balance between responsiveness and range.
+
+### [Failsafe](/control/failsafe/)
+What the quad does when it loses the control link. This is critical safety configuration. Common failsafe behaviors:
+- **Drop**: Motors cut immediately. Safest for populated areas (quad falls straight down).
+- **GPS Return to Home**: Quad flies back to launch point autonomously. Requires GPS module.
+- **Hold position**: Maintains altitude and position (requires GPS). Gives time for signal to reconnect.
+
+Configure your failsafe before your first flight. The default on many flight controllers is "do nothing," which means the quad keeps flying on its last commands if signal is lost.
+
+### [Telemetry](/control/telemetry/)
+Data sent back from the quad to your transmitter. Battery voltage, RSSI (signal strength), GPS coordinates, flight mode, and other values can display on your transmitter screen or announce via voice alerts. Telemetry helps you monitor battery levels and signal quality without looking away from your goggles.
+
+## Stick Modes
+
+Radio transmitters can be configured with different stick assignments:
+
+- **Mode 2** (most common worldwide): Left stick = throttle/yaw, right stick = pitch/roll
+- **Mode 1**: Left stick = pitch/yaw, right stick = throttle/roll
+- **Mode 3/4**: Less common variants
+
+Mode 2 is the overwhelming default in the FPV community. Unless you learned on Mode 1 and are comfortable with it, start with Mode 2 so that tutorials, buddy-boxing, and advice from other pilots all translate directly.

--- a/src/content/docs/control/protocols.md
+++ b/src/content/docs/control/protocols.md
@@ -1,23 +1,87 @@
 ---
-title: Transmitter Protocols
-description: Communication protocols between transmitter and receiver.
+title: Control Protocols
+description: RC link protocols — how your transmitter talks to your receiver.
 ---
 
-Protocols define how your transmitter talks to your receiver. The choice of protocol affects latency, range, and features.
+Control protocols define how commands travel from your radio transmitter to the receiver on your quad. The protocol determines latency, range, reliability, and what features are available. This space has evolved rapidly, and what was standard two years ago may already be obsolete.
 
-## Signal Protocols
+## Protocol Categories
 
-- **PWM** — Pulse Width Modulation. One wire per channel. Old school, rarely used for RC link anymore.
-- **PPM** — Pulse Position Modulation. Multiple channels on one wire. Legacy but still seen on older gear.
-- **SBUS** — Serial Bus. Digital protocol, faster than PPM and PWM. Was the common choice for FPV racing. Developed by Futaba/FrSky.
+There are two separate protocol layers to understand:
 
-## Modern Link Protocols
+### 1. RF Protocol (Over the Air)
+How the transmitter and receiver communicate wirelessly. This determines range, latency, frequency hopping behavior, and packet structure. Examples: ExpressLRS, Crossfire, FrSky ACCST, Flysky AFHDS.
 
-- **ELRS (ExpressLRS)** — Open-source, low-latency, long-range. The current community favorite.
-- **Crossfire (CRSF)** — TBS's long-range protocol. Reliable, battle-tested.
-- **FrSky** — ACCESS/ACCST protocols. Proprietary, large install base.
-- **Ghost** — ImmersionRC's low-latency protocol.
+### 2. Serial Protocol (On the Wire)
+How the receiver passes decoded channel data to the flight controller over a UART connection. Examples: CRSF, SBUS, IBUS, FPORT.
 
-## What to Choose
+You need both: an RF protocol to get signals to the quad, and a serial protocol to get those signals into the flight controller.
 
-For new builds in 2024+, **ELRS** is the default recommendation. Open-source, cheap, fast, and long-range. Hard to beat.
+## RF Protocols
+
+### ExpressLRS (ELRS)
+Open-source, community-developed. Available in 2.4GHz and 900MHz variants. ELRS has become the dominant protocol for new builds since 2023.
+
+Strengths:
+- Extremely low latency (under 5ms at 500Hz)
+- Excellent range (30km+ on 2.4GHz, 100km+ on 900MHz with proper antennas)
+- Update rates from 25Hz to 1000Hz (configurable)
+- Cheap hardware ($10-15 receivers, $25-40 TX modules)
+- Active open-source development with frequent firmware updates
+- Lua configuration script on EdgeTX radios
+
+The 2.4GHz version is recommended for most pilots. 900MHz is for dedicated long-range builds where you need maximum penetration and distance.
+
+### TBS Crossfire (CRSF)
+Team BlackSheep's proprietary 900MHz protocol. Was the gold standard for long-range control before ELRS matured. Still widely used and very reliable.
+
+- 900MHz only (better penetration through obstacles than 2.4GHz)
+- ~7ms latency at 150Hz
+- Range: 40km+ with standard antennas
+- More expensive than ELRS ($25-40 receivers, $50-80 TX module)
+- Proprietary but well-supported
+
+### TBS Tracer
+TBS's 2.4GHz protocol, designed for racing and proximity flying where range isn't the priority.
+- ~4ms latency at 250Hz
+- Range: 5km+ (shorter than ELRS 2.4GHz)
+- Low latency focus
+
+### FrSky
+Once the dominant protocol in the hobby. FrSky radios (Taranis series) were the standard recommendation for years. The protocol has fallen behind on latency and features, and community relations deteriorated after firmware lockout controversies.
+
+- **ACCST** (D8/D16): Legacy 2.4GHz protocol. Range limited to 1-2km. Latency around 15-20ms. Still works but no reason to choose it for new builds.
+- **ACCESS**: Newer FrSky protocol. Requires FrSky-specific receivers. Limited third-party support.
+
+If you already own FrSky gear, it works fine. For new purchases, ELRS or Crossfire are better investments.
+
+### Flysky AFHDS
+Budget protocol found on entry-level radios. Functional but limited range (500m-1km typical) and higher latency (~20ms). Fine for learning on a Tiny Whoop. Not recommended for anything you plan to fly beyond a park.
+
+## Serial Protocols (Receiver to FC)
+
+### CRSF (Crossfire Serial)
+Originally developed by TBS for Crossfire but now the de facto standard serial protocol. ELRS also uses CRSF for receiver-to-FC communication. Fast, bidirectional (supports telemetry upstream), and uses a single UART.
+
+### SBUS
+FrSky's serial protocol. Inverted signal (requires hardware inverter on some flight controllers, though most modern F4/F7 FCs handle it natively). One-directional without additional wiring for telemetry.
+
+### IBUS
+Flysky's serial protocol. Simple, uninverted, one-directional. Works on all UARTs without hardware modification.
+
+### FPORT
+FrSky's combined SBUS + telemetry on a single wire. Reduces wiring complexity compared to separate SBUS and SmartPort connections.
+
+## Choosing a Protocol
+
+For a new setup in 2024+:
+
+| Use Case | Recommendation |
+|----------|---------------|
+| General FPV (freestyle, casual racing) | ELRS 2.4GHz at 250-500Hz |
+| Competitive racing | ELRS 2.4GHz at 500-1000Hz |
+| Long range (7" builds, wings) | ELRS 900MHz at 100-200Hz |
+| Already own Crossfire gear | Crossfire is still excellent, no need to switch |
+| Absolute budget minimum | Flysky for a first Whoop, upgrade later |
+
+The protocol debate has largely been settled. ELRS won on performance, price, and ecosystem. Crossfire remains a solid alternative with a proven track record. Everything else is either legacy or niche.

--- a/src/content/docs/drive/brushed-vs-brushless.md
+++ b/src/content/docs/drive/brushed-vs-brushless.md
@@ -1,33 +1,59 @@
 ---
 title: Brushed vs. Brushless Motors
-description: Why brushless motors are the standard for FPV quads.
+description: The difference between brushed and brushless motors, and why FPV uses brushless.
 ---
 
-Both brushed and brushless DC motors use electromagnetism to spin. The difference is in how they're constructed and controlled.
+Every motor on an FPV quad is brushless. This wasn't always the case (early Tiny Whoops used brushed motors), but brushless has won completely. Understanding why helps you appreciate what your motors are doing and why they're built the way they are.
 
-## Brushed Motors
+## How Brushed Motors Work
 
-Brushed motors have copper windings and carbon brushes to generate force. The brushes make physical contact with the commutator, which causes wear over time.
+A brushed motor has copper wire windings on a rotating armature (the rotor) surrounded by fixed permanent magnets (the stator). Carbon "brushes" press against a commutator on the rotor shaft to deliver electrical current to the windings. As current flows through each winding, it creates a magnetic field that interacts with the permanent magnets, generating rotation. The commutator switches which winding is energized as the motor spins, keeping it turning.
 
-- Simpler, cheaper
-- Shorter lifespan (brushes wear out)
-- Less efficient (~75-80%)
-- Used in toy-grade drones and some micro quads
+This mechanical switching system (brushes rubbing against the commutator) is the fundamental weakness. The brushes wear down over time, create friction, generate electrical noise, and limit the motor's maximum speed and efficiency.
 
-## Brushless Motors
+## How Brushless Motors Work
 
-In a brushless motor, you lose the brushes and gain an electronic controller. Magnets in the bell surround a copper-wound stator. An ESC electronically commutates the motor — no physical contact, no wear.
+A brushless motor flips the design. The permanent magnets are on the rotor (the spinning bell), and the copper windings are on the stator (the fixed center). There are no brushes or commutator. Instead, an electronic speed controller (ESC) handles the switching, energizing the stator windings in sequence to pull the magnets around.
 
-- More complex (requires ESC)
-- Much longer lifespan
-- More efficient (~85-90%)
-- More torque at any given size
-- The standard for anything beyond toy-grade
+This electronic commutation eliminates mechanical contact between the electrical and moving parts. The result: less friction, less wear, less noise, more speed, and more efficiency.
 
-> Brushless motors are typically 85-90% efficient whereas brushed DC motors are around 75-80% efficient. This difference in efficiency means that more of the total power used by the motor is being turned into rotational force and less is being lost as heat.
->
-> *via [Quantum Devices](https://quantumdevices.wordpress.com/2010/08/27/brushless-motors-vs-brush-motors-whats-the-difference/)*
+## Why Brushless Wins
 
-## Bottom Line
+### Efficiency
+Brushless motors convert 85-90% of electrical energy into rotational force. Brushed motors manage 75-80%. That 10-15% difference means longer flight times or more power from the same battery.
 
-Brushed motors are for toys. Brushless motors are for serious machines. Every FPV racing or freestyle quad uses brushless motors.
+### Power Density
+Brushless motors produce significantly more torque and RPM for their size and weight. A 2306 brushless motor (23mm diameter, 6mm stator height) weighing 30g produces thrust that would require a brushed motor several times its size.
+
+### Lifespan
+Brushed motor brushes wear down through friction, typically lasting 50-200 hours of use. Brushless motors have only bearings as wear components, lasting thousands of hours with minimal degradation. For FPV, where motors take constant high-load abuse, this matters.
+
+### Heat Management
+Brushed motors generate heat through brush friction in addition to resistive losses in the windings. Brushless motors only generate heat from winding resistance and eddy currents. Less heat means the motor can sustain higher power without thermal throttling or damage.
+
+### Precision Control
+ESCs can control brushless motors with extreme precision through digital protocols like DShot. The ESC knows the exact rotor position and can adjust speed thousands of times per second. This precision is what allows flight controllers to stabilize a quad at 8kHz PID loop rates. Brushed motors can't be controlled with this level of accuracy due to the mechanical commutation lag.
+
+### Bidirectional RPM Feedback
+With bidirectional DShot, brushless motors report their actual RPM back to the flight controller. This enables RPM filtering in Betaflight, which removes motor-frequency noise from the gyro signal. This is impossible with brushed motors.
+
+## Where You Still Find Brushed
+
+Brushed motors persist in a few areas:
+- **Very cheap toy drones**: Sub-$30 toy quads use brushed motors because they don't need an ESC (the motor can be driven directly from a simple transistor circuit)
+- **Some legacy Tiny Whoop frames**: Early Whoop designs used brushed 6mm or 7mm motors. These have been almost entirely replaced by brushless 0802 and 1102 motors.
+
+If you're buying any FPV quad in 2024+, it will have brushless motors.
+
+## Brushless Motor Specifications
+
+When shopping for brushless motors, you'll see specs like "2306 1750KV":
+
+- **2306**: Stator dimensions. 23mm diameter, 6mm height. Larger stators produce more torque.
+- **1750KV**: RPM per volt with no load. A 1750KV motor on a 6S battery (25.2V fully charged) spins at approximately 44,100 RPM with no propeller. Under load, actual RPM is lower.
+
+Higher KV = faster spinning, less torque per revolution. Lower KV = slower spinning, more torque. For the same prop:
+- **High KV on lower voltage** (e.g., 2400KV on 4S): Higher current draw, hotter motors, similar performance
+- **Low KV on higher voltage** (e.g., 1750KV on 6S): Lower current draw, cooler running, same or better performance
+
+This is why the hobby has shifted from 4S to 6S. Lower KV motors on higher voltage achieve the same power with less current, which means less stress on ESCs, motors, and battery.

--- a/src/content/docs/drive/overview.md
+++ b/src/content/docs/drive/overview.md
@@ -1,23 +1,52 @@
 ---
-title: Drive Systems
-description: ESCs, motors, and propellers — what makes your quad move.
+title: Drive System
+description: Motors, ESCs, and propellers — the components that make your quad move.
 ---
 
-The drive system converts electrical energy into thrust. It's the chain from the flight controller's commands to spinning propellers.
-
-## The Chain
-
-```
-Flight Controller → ESC Signal → ESC → Motor → Propeller → Thrust
-```
+The drive system converts electrical energy from your battery into thrust. It consists of three main components working together: motors spin propellers to generate lift and thrust, while Electronic Speed Controllers (ESCs) regulate how fast each motor spins based on commands from the flight controller.
 
 ## Components
 
-- **[ESCs](/drive/escs/)** — Electronic Speed Controllers. Translate FC commands into motor speed.
-- **[Motors](/drive/motors/)** — [Brushless](/drive/brushed-vs-brushless/) for anything serious. Spin the props.
-- **[Propellers](/drive/propellers/)** — Generate lift and thrust. Size, pitch, and blade count all matter.
+### [Motors](/drive/motors/)
+Brushless motors are the standard for FPV quads. They're rated by size (e.g., 2306 means 23mm stator diameter, 6mm stator height) and KV (RPM per volt). Higher KV motors spin faster on the same voltage but produce less torque. Lower KV motors spin slower but push bigger propellers more efficiently.
 
-## Signal Types
+Common motor sizes by quad class:
+- **5" quads**: 2207, 2306, 2307 (1700-2600KV on 6S, 2400-2700KV on 4S)
+- **3" quads**: 1404, 1507 (3000-3800KV on 4S)
+- **Tiny Whoops**: 0802, 1102 (19000-25000KV on 1S)
 
-- **[PWM Signal](/drive/pwm-signal/)** — How ESCs interpret speed commands.
-- **[PPM Signal](/drive/ppm-signal/)** — An older multi-channel signal format.
+### [Electronic Speed Controllers (ESCs)](/drive/escs/)
+ESCs sit between the flight controller and the motors. They receive a digital signal (typically [DShot](/drive/pwm-signal/)) telling them how fast to spin each motor, then switch battery power to the motor windings in the correct sequence and timing to achieve that speed.
+
+Modern quads use either a 4-in-1 ESC (single board controlling all four motors) or individual ESCs wired to each motor. 4-in-1 ESCs are more common because they simplify wiring and save weight.
+
+Key ESC specs:
+- **Current rating**: Must handle peak motor draw. 35A-55A per motor is typical for 5" builds.
+- **Firmware**: BLHeli_32 or AM32 are the current standards. Both support bidirectional DShot for RPM filtering.
+- **Voltage rating**: Must match your battery (4S = 16.8V, 6S = 25.2V).
+
+### [Propellers](/drive/propellers/)
+Propellers convert motor rotation into thrust. They're described by diameter, pitch, and blade count (e.g., 5143 = 5.1" diameter, 4.3" pitch, 3 blades). Higher pitch means more aggressive bite and higher top speed but also more current draw. More blades increase grip and responsiveness at the cost of efficiency.
+
+For freestyle flying, tri-blade (3-blade) props are the most popular. Racing setups sometimes use bi-blade props for efficiency.
+
+## Signal Protocols
+
+The flight controller communicates with ESCs using digital signal protocols. The current standard is **DShot**, which replaced older analog protocols like PWM and OneShot.
+
+- **[PWM Signal](/drive/pwm-signal/)**: The original analog protocol. Slow (50Hz), requires calibration, no error checking. Obsolete for motor control but still used for servos.
+- **[PPM Signal](/drive/ppm-signal/)**: Multiplexes multiple PWM channels onto a single wire. Also obsolete for ESC control.
+- **DShot300/600**: Digital protocol. No calibration needed, includes CRC error checking, and supports bidirectional communication for RPM data. Use DShot300 as a safe default.
+
+### [Brushed vs. Brushless](/drive/brushed-vs-brushless/)
+Toy-grade drones use brushed motors. Everything in the FPV hobby uses brushless. Brushless motors are more efficient (85-90% vs 75-80%), produce more power for their size, last longer, and can be driven with precise digital protocols. The only place you might encounter brushed motors is in very cheap micro quads, and even those have largely moved to brushless.
+
+## Choosing Your Drive System
+
+For a first 5" freestyle build, a solid starting point:
+- **Motors**: 2306 or 2207, 1750-1950KV for 6S (or 2400-2550KV for 4S)
+- **ESC**: 4-in-1, 50A+ rated, BLHeli_32 or AM32 firmware
+- **Props**: 5" tri-blade (Gemfan 51466 or HQProp 5.1x3.1x3 are popular choices)
+- **Protocol**: DShot300 with bidirectional DShot enabled
+
+This combination gives you enough power for aggressive freestyle while remaining efficient enough for 3-5 minute flight times on a 1300-1500mAh 6S battery.

--- a/src/content/docs/drive/pwm-signal.md
+++ b/src/content/docs/drive/pwm-signal.md
@@ -1,18 +1,89 @@
 ---
 title: PWM Signal
-description: Pulse Width Modulation — how speed commands are encoded as signals.
+description: Pulse Width Modulation - how speed commands are encoded as signals.
 ---
 
-Pulse Width Modulation (PWM) is a type of digital signal used extensively in electronics. In the context of FPV quads, PWM signals are used to communicate speed commands to ESCs.
-
-> Pulse width modulation is used in a variety of applications including sophisticated control circuitry. A common way we use them is to control dimming of RGB LEDs or to control the direction of a servo motor.
->
-> *via [SparkFun](https://learn.sparkfun.com/tutorials/pulse-width-modulation)*
+Pulse Width Modulation (PWM) is a fundamental signal type in electronics. In the context of FPV quads, PWM has been used to communicate speed commands to ESCs, control servos, and dim LEDs. While it has been largely replaced by digital protocols like DShot for motor control, understanding PWM helps you work with older equipment and grasp how ESC communication evolved.
 
 ## How It Works
 
-A PWM signal rapidly switches between high and low voltage. The ratio of time spent "high" vs. the total cycle time (the **duty cycle**) encodes the desired value — in this case, motor speed.
+A PWM signal rapidly switches between high voltage (typically 3.3V or 5V) and low voltage (0V/ground). The signal has a fixed frequency, and within each cycle, the ratio of time spent "high" versus the total cycle time is called the **duty cycle**.
 
-## In Modern Quads
+- **0% duty cycle** = signal is always low (off)
+- **50% duty cycle** = signal is high half the time
+- **100% duty cycle** = signal is always high (full on)
 
-PWM as an ESC protocol has been largely replaced by **DShot** (a digital protocol) which is faster, more reliable, and doesn't require calibration. You'll still encounter PWM in servo control and older gear.
+For ESC motor control, the duty cycle maps to a throttle value. The ESC reads the width of each high pulse to determine how fast the motor should spin.
+
+### The Standard RC PWM Signal
+
+Traditional RC PWM (used since the earliest days of radio control) uses a specific convention:
+
+- **Signal frequency**: 50Hz (one pulse every 20ms)
+- **Minimum throttle**: 1000 microsecond pulse width
+- **Maximum throttle**: 2000 microsecond pulse width
+- **Center/idle**: 1500 microsecond pulse width
+
+So within each 20ms frame, the ESC looks at how long the signal stays high. A 1ms high pulse means zero throttle. A 2ms high pulse means full throttle. Everything in between is proportional.
+
+This 50Hz update rate means the flight controller can only send a new throttle command 50 times per second. For early drones this was fine, but as PID loop rates increased to 4kHz and 8kHz, the slow PWM signal became a bottleneck.
+
+## PWM Improvements: OneShot and MultiShot
+
+As FPV racing pushed the need for faster ESC response, several improved versions of PWM appeared:
+
+### OneShot125
+
+Same concept as standard PWM but with shorter pulse widths (125-250 microseconds) and no fixed frame rate. The FC sends a new pulse at the end of each PID loop iteration, so the update rate matches the FC loop rate (up to 4kHz). This was a significant latency improvement.
+
+### OneShot42
+
+Further compressed pulse widths (42-84 microseconds) for even faster communication. Allowed update rates beyond 4kHz.
+
+### MultiShot
+
+The fastest analog protocol, with pulse widths of 5-25 microseconds. Supported update rates up to 32kHz. MultiShot was the pinnacle of analog ESC protocols before digital protocols took over.
+
+## The Shift to DShot
+
+All of the PWM-based protocols share fundamental limitations:
+
+1. **Analog signal** - Susceptible to electrical noise, which can cause ESC desyncs or incorrect throttle readings.
+2. **Calibration required** - Each ESC needs to learn what "minimum" and "maximum" pulse widths are. If calibration drifts, motors spin unevenly.
+3. **No error checking** - If noise corrupts a pulse, the ESC has no way to know. It just interprets whatever it receives.
+4. **One-directional** - The FC sends commands but gets nothing back from the ESC.
+
+**DShot** (Digital Shot) solves all of these:
+
+- **Digital signal** - Sends actual numeric values (0-2047) instead of pulse widths. Immune to analog noise.
+- **No calibration** - 0 is zero throttle, 2047 is full throttle. Every ESC interprets it the same way.
+- **CRC error checking** - Each packet includes a checksum. If the data is corrupted, the ESC ignores it rather than spinning to a wrong speed.
+- **Bidirectional option** - With bidirectional DShot, the ESC sends RPM data back to the FC. This enables RPM filtering in Betaflight, which dramatically reduces motor noise in the gyro signal.
+
+Common DShot speeds:
+- **DShot150** - 150kbit/s. Slow, rarely used.
+- **DShot300** - 300kbit/s. The safe default for most builds. Works with virtually all ESCs.
+- **DShot600** - 600kbit/s. Faster updates but requires a reliable signal path. Use if your ESC supports it cleanly.
+
+## PWM in Servo Control
+
+While DShot has replaced PWM for motor control, PWM is still the standard for servo control. Servos on camera gimbals, fixed-wing control surfaces, and antenna trackers all use the traditional 50Hz PWM signal with 1000-2000 microsecond pulse widths.
+
+If you are building a fixed-wing FPV plane or a tilt-rotor, you will still configure PWM outputs in Betaflight for your servos.
+
+## PWM for LED Control
+
+PWM is also used to control LED brightness. By switching an LED on and off thousands of times per second and varying the duty cycle, you can smoothly dim from 0% to 100% brightness. This is how programmable LED strips (WS2812B and similar) on FPV quads achieve color mixing and effects.
+
+## Practical Summary
+
+| Protocol | Type | Speed | Calibration | Error Check | Direction |
+|----------|------|-------|-------------|-------------|-----------|
+| Standard PWM | Analog | 50Hz | Yes | No | One-way |
+| OneShot125 | Analog | Up to 4kHz | Yes | No | One-way |
+| OneShot42 | Analog | Up to 8kHz | Yes | No | One-way |
+| MultiShot | Analog | Up to 32kHz | Yes | No | One-way |
+| DShot300 | Digital | 300kbit/s | No | Yes (CRC) | Bidirectional |
+| DShot600 | Digital | 600kbit/s | No | Yes (CRC) | Bidirectional |
+
+For any new build, use **DShot300** as your ESC protocol. Enable **bidirectional DShot** if your ESCs support it (most BLHeli_32 and AM32 ESCs do) to take advantage of RPM filtering. You should only deal with PWM if you are working with servos or maintaining very old equipment.

--- a/src/content/docs/flight-school/overview.md
+++ b/src/content/docs/flight-school/overview.md
@@ -1,20 +1,78 @@
 ---
 title: Flight School
-description: Learn to fly — from simulator to real stick time.
+description: Learn to fly FPV — from your first hover to confident freestyle.
 ---
 
-Learning to fly FPV is a journey. It takes practice, patience, and a lot of crashes. But the payoff is incredible.
+Learning to fly FPV is a process. Most pilots spend weeks or months in a simulator before their first real flight, and that's the smart approach. Crashing a virtual quad costs nothing. Crashing a real one costs $20-200+ depending on what breaks.
 
-## Learning Path
+## The Learning Path
 
-1. **[Mode Comparison](/flight-school/mode-comparison/)** — Understand Acro vs. stabilized modes.
-2. **[Simulators](/flight-school/simulators/)** — Practice risk-free before flying a real quad.
-3. **[Flight 101](/flight-school/flight-101/)** — Your first real flights.
+### 1. Start with a Simulator
+Before buying a quad, get a radio transmitter and plug it into your computer. FPV simulators give you realistic physics and let you build muscle memory without risk. Most experienced pilots recommend 10-20 hours of sim time before your first real flight.
+
+Popular simulators:
+- **[Liftoff](https://www.liftoff-game.com/)**: Realistic physics, active multiplayer, good track editor
+- **[VelociDrone](https://www.velocidrone.com/)**: The most accurate physics for racing, widely used by competitive pilots
+- **[Uncrashed](https://store.steampowered.com/app/1682970/Uncrashed_FPV_Drone_Simulator/)**: Beautiful environments, good for freestyle practice
+- **[DRL Simulator](https://thedroneracingleague.com/simulator/)**: Free on Steam, decent physics
+
+See the [full simulators guide](/flight-school/simulators/) for setup instructions and tips.
+
+### 2. Understand Flight Modes
+Your flight controller can operate in different modes that change how the quad responds to your stick inputs. This is one of the most important concepts to understand before flying.
+
+- **Acro (Rate) mode**: The quad only rotates when you tell it to. Release the sticks and it holds whatever angle it's at. This is what every FPV pilot uses once they're comfortable. All freestyle tricks and racing require acro.
+- **Angle (Self-level) mode**: The quad automatically levels itself when you release the sticks. Easier for beginners but limits what you can do. Think of it as training wheels.
+- **Horizon mode**: A hybrid. Self-levels at small stick deflections but allows flips and rolls at full stick. Rarely used in practice.
+
+Read the [mode comparison](/flight-school/mode-comparison/) for a deeper breakdown.
+
+**Strong recommendation**: Learn acro from the start, even in the simulator. Transitioning from angle mode to acro later means relearning muscle memory. It feels harder at first but saves time overall.
+
+### 3. Your First Real Flight
+When you're comfortable hovering and doing basic maneuvers in the sim, it's time to fly for real.
+
+Find a large, open field with no people, cars, or obstacles nearby. A school field on a weekend or an empty park works well. Bring:
+- Your quad, fully charged and pre-flight checked
+- Goggles and transmitter
+- Spare batteries (at least 3-4)
+- Basic tools (prop nut wrench, zip ties, electrical tape)
+- A spotter if possible (someone watching the quad with line of sight)
+
+Your first flight goals are simple:
+1. Take off and hover at eye height
+2. Fly a slow circle around yourself
+3. Land gently (not crash-land, actually land)
+4. Do it again
+
+Don't try to fly fast, do tricks, or explore. Just get comfortable with the feeling of real flight, which is different from the simulator because of wind, weight, and the knowledge that crashes have consequences.
+
+### 4. Build Your Skills
+Once you can hover and fly basic patterns confidently:
+
+- **Orbits**: Fly circles around a fixed object (a tree, a post). This builds coordinated yaw and roll control.
+- **Figure-8s**: Combine left and right turns. Forces you to practice both directions.
+- **Power loops**: Your first "trick." Fly forward, pull back into a loop, and try to come out straight. Start high with plenty of altitude margin.
+- **Split-S**: From forward flight, roll inverted and pull back to reverse direction. Fundamental freestyle move.
+- **Proximity flying**: Once you trust your control, start flying closer to objects. Trees, buildings, gaps. This is where FPV gets fun.
+
+See [Flight 101](/flight-school/flight-101/) for detailed fundamentals.
+
+## Common Beginner Mistakes
+
+- **Starting in angle mode**: Makes the transition to acro harder. Learn acro from day one.
+- **Flying too high**: Stay low enough that crashes don't destroy everything. 10-30 feet is plenty while learning.
+- **Not using a simulator**: Real quads break. Sims don't. Put in the hours.
+- **Overtightening prop nuts**: Finger-tight plus a quarter turn. Overtightening strips motor shafts.
+- **Ignoring pre-flight checks**: Check props are on tight, battery is secure, and failsafe is configured before every flight.
+- **Chasing other pilots' skill level**: Everyone progresses at their own pace. Six months of regular flying gets most people to comfortable freestyle.
 
 ## How Long Does It Take?
 
-Most people can hover and fly basic circuits within a few hours of simulator time. Comfortable acro flying takes weeks to months. Smooth freestyle takes months to years. Racing competitively takes dedication.
+There's no fixed answer, but rough benchmarks:
+- **10-20 hours sim**: Comfortable hovering and basic maneuvers
+- **20-50 flights**: Confident flying lines, basic freestyle
+- **6-12 months regular flying**: Smooth freestyle, comfortable in tight spaces
+- **1-2 years**: Competition-ready racing or advanced freestyle
 
-## The Golden Rule
-
-**Crash, learn, repair, repeat.** Every pilot crashes. The difference between beginners and experienced pilots is just how many crashes are behind them.
+The pilots posting jaw-dropping clips online have thousands of hours of flight time. Don't compare your month two to their year five.

--- a/src/content/docs/fpv/overview.md
+++ b/src/content/docs/fpv/overview.md
@@ -1,30 +1,77 @@
 ---
-title: First-Person View (FPV)
-description: The video system that lets you see through your drone's eyes.
+title: FPV Video System
+description: Cameras, transmitters, receivers, and goggles — everything that lets you see through your drone.
 ---
 
-FPV is what makes drone racing and freestyle possible. A camera on the quad transmits live video to goggles on the ground, giving you a pilot's-eye view in real time.
+The FPV (First Person View) video system is what separates an FPV drone from a regular drone. Instead of watching your quad from the ground, you see what it sees through goggles or a monitor. A camera on the quad feeds video to a transmitter, which broadcasts it to a receiver connected to your display. The result is an immersive flying experience that feels like sitting in the cockpit.
 
-## The Video Chain
+## System Components
 
-```
-FPV Camera → Video Transmitter (VTX) → Radio Waves → Video Receiver (VRX) → Goggles/Monitor
-```
+Every FPV video system has four parts:
 
-## Components
+### [Camera](/fpv/camera/)
+Mounted at the front of the quad, angled upward to match your flying speed. FPV cameras are optimized for low latency rather than image quality. They need to handle rapid light changes (flying from sun into shadow) without washing out, and deliver frames with minimal delay.
 
-- **[Camera](/fpv/camera/)** — Captures the image. Low latency is critical.
-- **[Video Transmitter (VTX)](/fpv/vtx/)** — Broadcasts the video signal.
-- **[Video Receiver (VRX)](/fpv/vrx/)** — Receives the signal on the ground.
-- **[Goggles](/fpv/goggles/)** — Immersive display strapped to your face.
-- **[OSD (On Screen Display)](/fpv/osd/)** — Overlays telemetry data on the video feed.
-- **[Antenna](/fpv/antenna/)** — Critical for range and signal quality on both VTX and VRX.
+### [Video Transmitter (VTX)](/fpv/vtx/)
+Takes the camera signal and broadcasts it wirelessly. Power output (measured in milliwatts) determines range. Typical power levels: 25mW (pit mode / indoor), 200-400mW (park flying), 600-800mW (open field), 1W+ (long range).
+
+### [Video Receiver (VRX)](/fpv/vrx/)
+Receives the broadcast signal. Can be built into goggles or connected as an external module. Receiver quality and antenna choice significantly affect video range and clarity.
+
+### [Goggles](/fpv/goggles/)
+Your display. FPV goggles range from $50 box-style units to $650+ slim goggles with OLED screens. They're the most personal piece of gear since comfort and display quality directly affect your flying experience.
 
 ## Analog vs. Digital
 
-- **Analog** — Traditional. Low latency, lower image quality, cheaper. Still widely used.
-- **Digital (DJI, HDZero, Walksnail)** — HD image quality. Higher latency than analog but improving. The direction the hobby is moving.
+The biggest decision in your FPV video system is analog or digital.
+
+### Analog
+The original FPV technology. Camera outputs a composite video signal, VTX broadcasts on one of many 5.8GHz channels, any compatible receiver picks it up.
+
+**Pros:**
+- Cheapest entry point ($30-50 for camera + VTX)
+- Lowest latency (~10-20ms total system delay)
+- Universal compatibility (any analog camera works with any analog VTX/VRX)
+- Easy to troubleshoot (fewer failure modes)
+- Can share video with multiple receivers simultaneously
+
+**Cons:**
+- Low resolution (roughly equivalent to 480p)
+- Susceptible to interference (static, lines, multipath)
+- Image quality degrades with distance rather than cutting out cleanly
+
+### Digital Systems
+Modern FPV digital systems encode video digitally and transmit at much higher quality. See the [digital systems guide](/fpv/digital-systems/) for detailed comparisons.
+
+**Current digital options:**
+- **DJI O3/O4**: Best image quality, highest latency (~30-40ms). Dominant market share. Expensive ($180+ for VTX alone).
+- **HDZero**: Lowest latency digital system (~15-20ms). Open ecosystem, community-driven firmware. Image quality improving with each generation.
+- **Walksnail Avatar**: Good balance of quality and latency. Backed by Caddx/FatShark.
+
+**Digital pros:**
+- HD image quality (720p-1080p in goggles)
+- Clean signal up to max range, then sudden cutoff (no gradual degradation)
+- Built-in OSD rendering
+- Firmware updates improving performance over time
+
+**Digital cons:**
+- More expensive than analog
+- Higher latency than analog (varies by system)
+- Less interoperability (DJI goggles only work with DJI VTX, etc.)
+
+## Antennas
+
+[Antennas](/fpv/antenna/) have an outsized impact on video performance. A mediocre VTX with a great antenna outperforms a powerful VTX with a bad antenna.
+
+Key concepts:
+- **Polarization**: FPV uses circular polarization (RHCP or LHCP). Both TX and RX antennas must match.
+- **Directional vs. omnidirectional**: Omni antennas receive from all directions (standard for quads). Directional antennas (patches, helicals) focus reception in one direction for more range.
+- **Diversity**: Many goggles support two antennas (one omni, one directional) and automatically use whichever has the stronger signal.
 
 ## Etiquette
 
-FPV frequencies are shared. [Read the etiquette guide](/fpv/etiquette/) before flying with others.
+[FPV etiquette](/fpv/etiquette/) matters when flying with others. Multiple pilots on the same video channel cause interference. Analog pilots need to coordinate channel assignments before flying. Digital systems handle this automatically with their own protocols.
+
+## [OSD (On-Screen Display)](/fpv/osd/)
+
+The OSD overlays flight data on your video feed: battery voltage, current draw, flight time, RSSI, GPS coordinates, warnings, and more. It's configured in Betaflight and is your primary instrument panel during flight. At minimum, always display battery voltage so you know when to land.

--- a/src/content/docs/frame/micro.md
+++ b/src/content/docs/frame/micro.md
@@ -1,20 +1,74 @@
 ---
-title: Micro Quads
-description: Micro quads — tiny drones for indoor and close-quarters FPV.
+title: Micro Frames
+description: Small frames under 150mm for indoor and backyard flying.
 ---
 
-Micro quads are the smallest class of FPV drones, typically under 150mm motor-to-motor. They're perfect for indoor flying, tight spaces, and learning.
+A quadcopter smaller than 150mm motor-to-motor (measured diagonally) is generally considered a micro. This category includes everything from palm-sized Tiny Whoops to 3" prop builds that punch well above their weight class.
 
-## Common Micro Sizes
+## Why Micros?
 
-- **65mm (Tiny Whoop class)** — The iconic indoor FPV quad. Ducted props, lightweight, safe enough to fly in your living room.
-- **75mm** — Slightly more power than a 65mm. Still safe indoors.
-- **85-95mm (Toothpick class)** — Outdoor-capable micros. No ducts, 2" props.
-- **100-150mm (Cinewhoop / 3" class)** — Larger micros that bridge the gap to miniquads.
+Micros fill a niche that larger quads can't. They're light enough to fly safely indoors, quiet enough to fly in neighborhoods without complaints, and durable enough to bounce off walls and furniture without damage. Many pilots keep a micro around for days when conditions or locations don't suit a 5" quad.
 
-## Why Fly Micro?
+Practical advantages:
+- **Fly anywhere**: Indoors, backyards, parks, parking garages. Places where a 5" would be dangerous or unwelcome.
+- **Low risk**: A 30g Tiny Whoop bouncing off someone's head is a laugh. A 700g freestyle quad is an emergency room visit.
+- **Cheap crashes**: Props cost pennies and frames are $10-20. You can send it with zero stress.
+- **Year-round flying**: When wind or cold makes outdoor flying miserable, micros let you fly in your living room.
+- **Practice anywhere**: Building muscle memory doesn't require a field and a full kit. Just charge a battery and fly.
 
-- Cheap to build and crash
-- Fly indoors year-round
-- Great for learning throttle control and proximity flying
-- Less intimidating than a full-size 5" quad
+## Common Micro Classes
+
+### Tiny Whoop (65mm-75mm)
+The smallest practical FPV quads. Ducted props (propeller guards built into the frame), brushless motors (0802 or 1102), and 1S batteries. Weigh 25-35g. Originally based on the Blade Inductrix, the "Whoop" style has become its own massive subcategory.
+
+Popular frames: BetaFPV 65mm/75mm, Happymodel Mobula/Moblite frames, Newbeedrone frames.
+
+See the [Tiny Whoop guide](/drone-types/tiny-whoop/) for a deep dive.
+
+### 2" Micro (80mm-100mm)
+Step up from Whoops. Can run ducted or open prop designs. Usually 1S-2S with 1102-1202 motors. More power and speed than Whoops while still being indoor-friendly with ducts.
+
+### 2.5" Toothpick (100mm-120mm)
+Open prop design, no ducts. Much faster and more agile than ducted micros. Typically 1S-2S with 1103-1404 motors. The "toothpick" name comes from their ultra-thin, lightweight frames. Not indoor-safe due to exposed props, but great for backyard flying.
+
+### 3" Micro (120mm-150mm)
+The biggest micros, and arguably the sweet spot for outdoor micro flying. 3" props on 1404-1507 motors with 2S-4S batteries produce real power. These can handle moderate wind and fly with authority. Many 3" builds come in under 250g, keeping them below regulatory thresholds in some countries.
+
+Popular frames: Diatone Roma F35, Flywoo Firefly, iFlight Archer.
+
+## Frame Materials
+
+- **Molded plastic (polypropylene)**: Standard for Tiny Whoops. Light, flexible, absorbs impacts. Breaks eventually but costs $3-8 to replace.
+- **Carbon fiber**: Used on 2.5" and 3" builds. Stronger and stiffer than plastic but heavier and transfers impact to components rather than flexing.
+- **TPU (3D-printed)**: Common for canopies, camera mounts, and battery pads on micros. Flexible and easy to customize if you have a 3D printer.
+
+## Weight Matters
+
+At the micro scale, every gram counts. A 5g difference on a 30g Tiny Whoop is a 17% weight change. That noticeably affects flight time, agility, and how fast the motors sag under load.
+
+Common weight-saving moves:
+- Use lighter batteries (check reviews for actual weights, they vary between batches)
+- Trim antenna wires to minimum safe length
+- Use lightweight receivers (ExpressLRS 2.4GHz nano RX weighing 0.5-1g)
+- Skip unnecessary features (LED strips, buzzers) if weight is critical
+- Sand or trim excess carbon from frame arms
+
+## Electronics Sizing
+
+Micro builds use smaller electronics than 5" quads:
+
+| Component | Typical Size |
+|-----------|-------------|
+| Flight controller | 16x16mm or 20x20mm mounting |
+| ESC | Integrated AIO (all-in-one with FC) or 16x16mm 4-in-1 |
+| VTX | Nano/micro size, 25-400mW |
+| Camera | Nano (14mm) or micro (19mm) |
+| Receiver | Nano ELRS or built into FC |
+
+All-in-one (AIO) boards that combine FC, ESC, and sometimes VTX onto a single board are very popular for micro builds. They save weight and simplify wiring significantly. The Happymodel CrazyF4 and BetaFPV F4 AIO are commonly used.
+
+## Getting Started with Micros
+
+If you're considering a micro as your first FPV quad, a bind-and-fly (BNF) Tiny Whoop is the lowest-risk entry point. BetaFPV Meteor75, Happymodel Mobula7, and EMAX TinyHawk are all proven options. Pair one with budget goggles and a compatible radio, and you can be flying the same day.
+
+For experienced pilots wanting a micro for variety, a 3" build on 4S is the most satisfying option. It flies like a scaled-down 5" quad with enough power for real freestyle, while being light enough to fly in spaces where a full-size quad would be irresponsible.

--- a/src/content/docs/frame/miniquad.md
+++ b/src/content/docs/frame/miniquad.md
@@ -1,20 +1,77 @@
 ---
 title: Miniquad
-description: Miniquads — the standard FPV racing and freestyle platform.
+description: The standard FPV racing and freestyle quadcopter — 150mm to 350mm.
 ---
 
-A Miniquad (or Mini Quadcopter) is usually intended for FPV racing purposes (as opposed to aerial photography) and is considered to be sized from around 150mm to 350mm motor-to-motor diagonally. Smaller than that and it is usually considered a [Micro](/frame/micro/) or Micro-quad.
+A miniquad is the standard platform for FPV freestyle and racing. Measured from 150mm to 350mm motor-to-motor diagonally, these quads are large enough to carry proper electronics and batteries while remaining nimble enough for aggressive flying. When someone says "FPV drone," they usually mean a 5" miniquad.
 
-## Common Sizes
+## The 5" Standard
 
-- **5" (5-inch props)** — The most popular racing and freestyle size. Frames typically 200-250mm. Great balance of power, agility, and flight time.
-- **6"** — Longer range, smoother video. Popular for cinematic freestyle.
-- **7"** — Long-range cruisers. Efficient but less agile.
+The 5-inch propeller quad has become the default for good reason. It hits the sweet spot between power, efficiency, flight time, and parts availability. Nearly every motor, frame, ESC, and prop manufacturer optimizes their products for the 5" class first.
 
-## What Makes a Good Race Quad?
+A typical 5" freestyle miniquad:
+- **Frame**: 220-250mm, true-X or squished-X geometry
+- **Motors**: 2306 or 2207, 1750-1950KV for 6S
+- **Props**: 5" tri-blade (Gemfan 51466, HQProp 5.1x3.1x3)
+- **Battery**: 6S 1300-1550mAh LiPo
+- **AUW (all-up weight)**: 650-850g with battery
+- **Flight time**: 3-6 minutes depending on throttle management
 
-- Low weight (under 700g with battery for 5")
-- Stiff carbon fiber frame
-- High-KV brushless motors
-- Low-latency FPV system
-- Reliable radio link
+## Frame Geometry
+
+### True-X
+Arms are evenly spaced at 90-degree intervals. Equal motor distances from center of gravity. The most balanced geometry for general flying. Most freestyle frames use true-X.
+
+### Squished-X (Stretched-X)
+Front and rear motor pairs are closer together, rear motors pushed out. This changes the moment arm, potentially improving yaw authority and high-speed stability. More common in racing frames. The difference is subtle and mostly matters at competitive levels.
+
+### Deadcat
+Rear arms angled wider than front arms so propellers stay out of camera view. Used on cinematic builds where a clean HD recording matters more than agility. Less common now that action cameras are typically mounted high enough to avoid prop-in-view issues.
+
+### Other Geometries
+- **H-frame**: Arms parallel rather than splayed. Easier to manufacture but worse aerodynamically. Mostly obsolete.
+- **Hybrid-X**: Slight variations on true-X. Marketing differentiation more than functional difference.
+
+## Frame Construction
+
+### Carbon Fiber
+Nearly all miniquad frames use 3K carbon fiber plate. Common thicknesses:
+- **Arms**: 5mm-6mm for freestyle (crash durability), 4mm for racing (weight savings)
+- **Top/bottom plates**: 2mm-3mm
+- **Standoffs**: Aluminum or steel, connecting top and bottom plates with the FC stack in between
+
+Frame quality varies significantly. Cheap carbon fiber uses lower-grade weave and resin that splinters on impact. Good frames (Armattan, ImpulseRC, Five33, Source One) use tighter weave and better resin for cleaner breaks and higher strength.
+
+### Hardware
+Most frames use M3 bolts with steel or aluminum standoffs. Motor mounting is standardized at 16x16mm (for smaller motors) or 16x19mm patterns. Props mount to motor shafts via self-tightening lock nuts (most common) or T-mount press-fit (DJI-style motors).
+
+## Frame Selection
+
+Choosing a frame comes down to your flying style and priorities:
+
+**Freestyle priorities:**
+- Thick arms (5mm+) for crash durability
+- Room for a full-size action camera mount
+- Easy access to electronics for repairs
+- Replaceable arms (individual arm replacement saves money vs. replacing the whole bottom plate)
+
+**Racing priorities:**
+- Low drag profile
+- Lightweight (sub-100g frame weight)
+- Aerodynamic canopy
+- Thin arms (4mm) where weight beats durability
+
+**Budget option:**
+The [Source One](https://github.com/tbs-trappy/source_one) is an open-source frame design. Multiple manufacturers produce it, keeping prices low ($15-25 for a complete frame kit). It flies well, parts are everywhere, and it's a solid choice for a first build.
+
+## Beyond 5"
+
+### 6" and 7" Long Range
+Larger props are more efficient at lower RPM. Long-range builds use 6" or 7" props with lower-KV motors on 6S to maximize flight time. 10-15 minute flights are achievable. Frames are typically 270-320mm.
+
+### 4" Builds
+A growing category. 4" props on smaller frames (170-200mm) create quads that are more agile than 5" builds but more capable than 3" micros. Some 4" builds stay under 250g for regulatory advantages. Popular for park flying where a 5" feels like overkill.
+
+## Compared to Micros
+
+The main tradeoff between a miniquad and a [micro](/frame/micro/) is capability vs. accessibility. A 5" miniquad flies faster, carries more equipment, handles wind better, and produces superior HD footage. But it's also louder, heavier, more dangerous, and requires more space to fly safely. Many pilots own both: a 5" for open-field sessions and a Whoop or 3" micro for everything else.

--- a/src/content/docs/frame/overview.md
+++ b/src/content/docs/frame/overview.md
@@ -1,32 +1,79 @@
 ---
 title: Frame
-description: Quad frames — sizes, materials, and configurations.
+description: The skeleton of your quad — materials, sizes, and geometry.
 ---
 
-Frames are usually measured in mm length motor-to-motor, diagonally. Common sizes for race quads range from 300mm to 185mm for 5-inch (5") propellers. 4-inch (4") propeller copters usually range from 150mm to 180mm, while smaller quads are considered [Micros](/frame/micro/).
+The frame is the foundation of every build. It holds all your electronics, absorbs crash impacts, and determines your quad's size class, weight, and aerodynamic profile. Frame choice affects everything from durability to how easy it is to work on.
 
-## Frame Types
+## Frame Sizing
 
-### H Frame
+Frames are measured in millimeters from one motor mount to the diagonally opposite motor mount. The size determines what propeller you can run:
 
-A traditional frame layout where the arms extend from a central body shaped like an H. Provides good stability and easy component mounting.
+| Frame Size | Prop Size | Typical Use |
+|-----------|-----------|-------------|
+| 65-75mm | 31mm (1.2") | Tiny Whoop |
+| 80-100mm | 2" | Indoor micro |
+| 100-120mm | 2.5" | Toothpick |
+| 120-150mm | 3" | [Micro](/frame/micro/) |
+| 170-200mm | 4" | Light freestyle |
+| 210-260mm | 5" | [Standard freestyle/racing](/frame/miniquad/) |
+| 270-320mm | 6-7" | Long range |
 
-### X Frame
+The 5" (210-260mm) class is the most popular and has the widest parts selection.
 
-Arms are arranged in an X pattern with equal spacing. The most common racing frame configuration — symmetrical thrust distribution.
+## Geometry
 
-### Stretch-X Frame
+Frame geometry describes how the arms are arranged relative to the center body.
 
-A variation of the X frame where the front-to-back distance is longer than the side-to-side distance. Popular for freestyle and racing — reduces prop wash interaction.
+### True-X
+All four arms are equally spaced at 90-degree intervals from center. Equal motor distance from the center of gravity in both pitch and roll axes. The most balanced layout for general flying. Most freestyle frames use true-X.
 
-### Other Notable Frame Designs
+### Stretched-X (Squished-X)
+Front motors are closer together than rear motors (or vice versa). This changes the effective moment arm for pitch vs. roll, which can improve high-speed pitch stability. Stretched-X frames are popular in racing where straight-line speed and fast direction changes matter.
 
-- **Dead Cat** — Wide front arms, narrow rear. Keeps props out of camera view.
-- **True-X** — Perfectly symmetrical X layout.
-- **Hybrid-X** — Somewhere between a true X and stretch X.
+### Deadcat
+Rear arms angle wider than front arms so that the rear propellers are out of the camera's field of view. Useful for cinematic builds where a clean recording matters. Less common now since action cameras are typically mounted high enough that prop-in-view isn't an issue on standard frames.
 
-## Frame Materials
+### H-Frame
+Arms run parallel in pairs rather than radiating from center. Simpler to manufacture but aerodynamically inferior to X layouts. Mostly historical at this point.
 
-- **Carbon Fiber** — The standard. Strong, lightweight, stiff. Most race frames are 3K or 4K carbon fiber.
-- **Aluminum** — Heavier but cheaper. Used in some beginner frames.
-- **3D Printed (TPU/PLA)** — Common for micro frames, camera mounts, and accessories.
+## Materials
+
+### Carbon Fiber
+The standard material for FPV frames. 3K woven carbon fiber plate offers excellent stiffness-to-weight ratio and withstands impacts well. Quality varies between manufacturers:
+- **Arm thickness**: 5mm-6mm for freestyle (crash durability), 4mm for racing (weight savings)
+- **Top/bottom plates**: 2mm-3mm
+- **Weave quality**: Better carbon uses tighter weave and higher-quality epoxy resin. Cheap carbon splinters badly on impact. Quality carbon breaks cleanly.
+
+### TPU (3D Printed)
+Thermoplastic polyurethane is used for non-structural parts: camera mounts, antenna mounts, GPS holders, battery pads, and canopies. TPU is flexible and absorbs impact rather than transmitting it to electronics. If you have a 3D printer, TPU accessories are one of the best quality-of-life upgrades.
+
+### Aluminum and Steel
+Used for standoffs (the posts connecting top and bottom plates) and motor mounting hardware. Aluminum is lighter, steel is stronger. Motor bolts are typically M3 steel.
+
+## Frame Components
+
+A typical frame kit includes:
+
+- **Bottom plate**: Main structural piece. Arms are either cut as part of this plate (unibody) or separate pieces bolted to it.
+- **Top plate**: Covers the electronics stack. Usually thinner than the bottom plate since it takes less direct impact.
+- **Arms**: Can be unibody (one piece with bottom plate) or replaceable individual arms. Replaceable arms cost less to repair per crash but add weight from the arm-to-body hardware.
+- **Standoffs**: Aluminum or steel posts with M3 threads, creating space for the electronics stack between top and bottom plates. Stack height (distance between plates) must accommodate your 4-in-1 ESC, FC, and any other stacked boards.
+- **Camera side plates**: Small carbon plates that form the front camera mount. Standard widths are 28mm (full), 21mm (mini), 19mm (micro), and 14mm (nano).
+- **Hardware kit**: All the M3 bolts, nuts, and standoffs needed for assembly.
+
+## Choosing a Frame
+
+Key considerations:
+
+**Arm design**: Replaceable arms are cheaper per crash (replace one $5 arm instead of a $20 bottom plate), but unibody is stiffer and lighter. For beginners who crash a lot, replaceable arms save money.
+
+**Stack mounting**: Most frames use 20x20mm or 30.5x30.5mm mounting patterns for the electronics stack. Some support both. Verify your FC and ESC match the frame's mounting pattern.
+
+**Camera mount width**: Must match your FPV camera size. Most 5" frames use full-size (28mm) mounts. Check before buying.
+
+**Action camera mount**: If you plan to record HD footage, the frame needs a solid mounting point for a GoPro or similar. TPU mounts are standard. Some frames have integrated carbon camera plates.
+
+**Weight**: Frame weight for a 5" build ranges from 60g (ultralight racing) to 120g+ (heavy-duty freestyle). Heavier frames are generally more durable but reduce agility and flight time.
+
+**Budget pick**: The [Source One](https://github.com/tbs-trappy/source_one) open-source frame is available from multiple manufacturers for $15-25 and flies well. It's a proven starting point.

--- a/src/content/docs/getting-started/anatomy.md
+++ b/src/content/docs/getting-started/anatomy.md
@@ -1,31 +1,67 @@
 ---
 title: Anatomy of a Quad
-description: The components that make up a quadcopter, in loose build order.
+description: Every component on an FPV quadcopter, explained.
 ---
 
-Every quad is built from the same core components. Here they are in loose build order:
+An FPV quadcopter is made up of several systems working together. Understanding what each part does and how they connect helps you build, repair, and troubleshoot your quad. Here's every major component, roughly in the order you'd assemble them.
 
-## Core Components
+## The Frame
 
-1. **Frame** — The structural skeleton that holds everything together.
-2. **Power Distribution** — Distributes battery power to all components.
-3. **ESCs** — Electronic Speed Controllers that drive each motor.
-4. **Motors** — Spin the propellers. Brushless for anything serious.
-5. **Flight Controller + Software** — The brain. Reads sensors, runs PID loops, stabilizes flight.
-6. **Receiver (RX)** — Receives commands from your radio transmitter.
+The [frame](/frame/overview/) is the skeleton. Carbon fiber plates bolted together with aluminum standoffs. It holds everything, takes the hits, and determines your quad's size class. Frames are measured diagonally motor-to-motor. A 5" quad typically has a 220-250mm frame.
 
-:::tip
-You should be able to hover and fly line-of-sight at this point. To add First-Person View, you'll need the components below.
-:::
+## Power System
 
-## FPV Components
+### Battery
+A [LiPo battery](/power/battery/) provides all the power. Most 5" quads run 6S (22.2V nominal). The battery mounts on top or bottom of the frame, secured with a strap. It's the heaviest single component on the quad.
 
-- **Camera** — Captures the live video feed from the quad.
-- **Video Transmitter (VTX)** — Broadcasts the video signal.
-- **Video Receiver (VRX)** — Receives the video signal on the ground.
-- **Display** — Goggles or monitor to view the feed.
+### Power Distribution
+Battery power reaches the ESCs through a [power distribution board (PDB)](/power/pdb/) or, more commonly on modern builds, through the 4-in-1 ESC which handles distribution internally. The ESC or PDB also provides regulated lower voltages (5V, 9V) for the flight controller and other electronics.
 
-## Extra Credit
+## Drive System
 
-- **LEDs** — Make your quad stand out and help with orientation.
-- **Telemetry** — Get real-time data like battery voltage and signal strength.
+### Electronic Speed Controllers (ESCs)
+[ESCs](/drive/escs/) control motor speed. They receive digital commands ([DShot](/drive/pwm-signal/)) from the flight controller and switch battery power to the motor windings at the right timing and speed. Most builds use a single 4-in-1 ESC board mounted in the electronics stack.
+
+### Motors
+Four [brushless motors](/drive/motors/) spin the [propellers](/drive/propellers/). They're bolted to the frame arms. Two spin clockwise, two counter-clockwise to cancel out rotational torque. Motor size (stator dimensions) and KV (RPM per volt) determine how much power and torque they produce.
+
+### Propellers
+[Propellers](/drive/propellers/) generate thrust. Defined by diameter, pitch, and blade count (e.g., 5143 = 5.1" diameter, 4.3" pitch, 3 blades). They're the cheapest component and the most frequently replaced since they break on every hard crash.
+
+## Flight Control
+
+### Flight Controller (FC)
+The [flight controller](/building/flight-controller/) is the brain. A small circuit board running firmware (usually Betaflight) that reads gyroscope data thousands of times per second and adjusts motor speeds to keep the quad stable and responsive. It also manages the OSD, receives commands from the radio receiver, and provides UART ports for peripherals.
+
+The FC mounts in the center of the electronics stack (typically above the ESC) on vibration-dampening grommets or silicone standoffs.
+
+### Receiver (RX)
+The [receiver](/control/receiver/) picks up commands from your radio transmitter. It connects to the FC via a UART serial connection. Modern receivers ([ELRS](/control/elrs/), Crossfire) are tiny and mount anywhere with space, often zip-tied to a standoff or tucked inside the frame.
+
+## FPV Video
+
+### FPV Camera
+The [FPV camera](/fpv/camera/) mounts at the front of the frame, angled upward. It's optimized for low latency and fast light response rather than recording quality. On analog systems, it outputs composite video. On digital systems (DJI, HDZero, Walksnail), it connects directly to the air unit.
+
+### Video Transmitter (VTX)
+The [VTX](/fpv/vtx/) broadcasts the camera feed to your goggles. On analog systems, it's a separate module in the electronics stack. On digital systems, the VTX is the air unit (camera plugs directly into it). VTX power (25mW to 1W+) determines video range.
+
+### Antenna
+The VTX [antenna](/fpv/antenna/) should point upward and away from carbon fiber. Antenna choice and placement affect video range more than VTX power. Circular polarized antennas (RHCP or LHCP) are standard.
+
+## On the Ground
+
+### Radio Transmitter (TX)
+Your [radio transmitter](/control/radio-transmitter/) is the controller in your hands. Sticks send roll, pitch, yaw, and throttle commands to the quad's receiver. Also provides switches for arming, flight mode changes, and other functions.
+
+### Goggles
+FPV [goggles](/fpv/goggles/) receive the video feed and display it on screens in front of your eyes. They range from budget box-style ($50-80) to slim OLED units ($400-650). This is the most personal gear choice since comfort and screen quality directly affect your experience.
+
+## Optional Extras
+
+- **[LEDs](/power/leds/)**: Programmable strips for visibility and style
+- **[Telemetry](/control/telemetry/)**: Flight data sent back to your transmitter
+- **GPS module**: Enables return-to-home failsafe and position hold
+- **Action camera**: GoPro or similar for HD recording (separate from the FPV camera)
+- **Buzzer**: Helps locate crashed quads by beeping on command
+- **Capacitor**: Smooths battery voltage spikes, reduces electrical noise

--- a/src/content/docs/getting-started/introduction.md
+++ b/src/content/docs/getting-started/introduction.md
@@ -1,30 +1,71 @@
 ---
-title: Introduction
-description: Welcome to the FPV Bible — your comprehensive guide to FPV drones.
+title: Introduction to FPV
+description: What is FPV flying, and is it for you?
 ---
 
-Welcome to the FPV Bible — a comprehensive, open-source guide to building First-Person-View (FPV) racing drones, and drones in general.
+FPV stands for First Person View. Instead of watching your drone from the ground, you wear goggles that show a live video feed from a camera on the drone. It feels like you're sitting in the cockpit, flying at 80+ mph through trees, around buildings, and across landscapes. It's the closest thing to actual flight that most people will experience.
 
-Whether you're a complete beginner wondering what FPV even stands for, or an experienced pilot looking for a reference, this guide is for you.
+## What Makes FPV Different
 
-## What is FPV?
+Regular drones (like a DJI Mavic) fly themselves. You point a stick and the GPS, obstacle avoidance, and stabilization software handle the rest. They're cameras that happen to fly.
 
-FPV stands for **First-Person View**. It's a method of flying a drone (or other RC vehicle) using a camera mounted on the aircraft that transmits a live video feed to goggles or a monitor. You see what the drone sees, in real time.
+FPV quads are the opposite. You control every axis of movement directly. The quad goes exactly where your thumbs tell it to go, and nowhere else. There's no GPS hold, no obstacle avoidance, no altitude hold (in standard acro mode). It's manual control at high speed, and that's what makes it rewarding.
 
-## What You'll Learn
+## Styles of FPV
 
-This guide covers everything from the ground up:
+### Freestyle
+The most popular style. Flying creatively through environments, doing tricks, flowing through gaps and around structures. Freestyle is what most FPV YouTube videos showcase. No rules, no course, just you and whatever terrain you find interesting.
 
-- **Frame** — The skeleton of your quad. Sizes, materials, configurations.
-- **Power** — Batteries, power distribution, voltage regulators.
-- **Control** — Radio transmitters, receivers, protocols, telemetry.
-- **Drive** — ESCs, motors (brushed vs. brushless), propellers.
-- **FPV Gear** — Cameras, video transmitters/receivers, goggles, antennas.
-- **Building** — Step-by-step assembly from bare frame to flying quad.
-- **Flight School** — Modes, simulators, and your first flights.
-- **Recording** — DVR, HD recording for sharing your flights.
-- **Tools & Accessories** — Everything you need on and off the field.
+### Racing
+Organized competition on a set course with gates, flags, and timing. Pilots fly simultaneously (up to 8 in MultiGP races). Racing rewards precision, consistency, and line optimization. There are local leagues, national championships, and international events.
 
-## Contributing
+### Cinematic
+Using FPV quads to capture smooth, dramatic footage. Real estate tours, event coverage, nature documentaries, film production. FPV cinematography has become a professional field with paid gigs. The "one-take" FPV style popularized by pilots like JohnnyFPV and Nurk has appeared in Super Bowl commercials, music videos, and feature films.
 
-This is an open-source project. If you see outdated information or something that can be improved, pull requests are welcome on [GitHub](https://github.com/lacymorrow/fpv-bible).
+### Long Range
+Flying FPV quads over long distances (5-100+ km). Larger quads with efficient setups, GPS, and long-range control links. Long range pilots prioritize flight time and signal integrity. This overlaps with the fixed-wing FPV community, which uses airplanes and flying wings for extreme endurance.
+
+### Tiny Whoop
+Indoor FPV racing and freestyle using palm-sized ducted quads. Safe enough to fly in your living room. Whoop racing leagues exist with organized indoor events. It's the lowest-risk, lowest-cost way to experience FPV.
+
+## What You Need to Get Started
+
+A complete FPV setup has three parts:
+
+1. **The quad**: Either built from parts or purchased as a bind-and-fly (BNF) package
+2. **Goggles**: To see the video feed from the quad's camera
+3. **Radio transmitter**: The controller in your hands that sends commands to the quad
+
+**Budget reality:**
+- Entry-level (Tiny Whoop + budget goggles + radio): $150-250
+- Mid-range (5" BNF quad + decent goggles + radio): $400-700
+- Full freestyle setup (custom build + HD digital + quality radio): $800-1500
+
+These are equipment costs. Budget for spare propellers, batteries, a charger, and inevitable crash repairs.
+
+## The Learning Curve
+
+FPV has a steep learning curve, but it's not as intimidating as it looks. Most pilots follow this path:
+
+1. **Simulator** (10-20 hours): Plug your radio into a computer and practice in VelociDrone, Liftoff, or another sim. This builds muscle memory for free.
+2. **First flights** (weeks 1-4): Hovering, basic turns, landing without crashing. Expect to break props.
+3. **Building confidence** (months 1-3): Longer flights, faster flying, first tricks (power loops, rolls).
+4. **Finding your style** (months 3-12): Deciding if you prefer freestyle, racing, cinematic, or all of the above.
+
+The community is helpful. Local flying groups, Discord servers, Reddit (r/fpv, r/Multicopter), and YouTube tutorials cover everything from first build to advanced techniques.
+
+## Is It For You?
+
+FPV is for you if:
+- You enjoy hands-on hobbies that combine building and doing
+- You like the idea of piloting something fast through 3D space
+- You're okay with breaking things and fixing them (crashes happen)
+- You want a hobby with deep technical and creative dimensions
+- You have outdoor space to fly (or indoor space for Whoops)
+
+FPV is probably not for you if:
+- You want a drone that flies itself while you take photos
+- You're looking for something you can master in an afternoon
+- Soldering, configuring firmware, and troubleshooting electronics sounds like a chore rather than part of the fun
+
+The rest of this guide covers everything you need to know. Start with the [anatomy of a quad](/getting-started/anatomy/) to understand the hardware, then move to [choosing your first drone](/getting-started/first-drone/) when you're ready to buy.

--- a/src/content/docs/power/overview.md
+++ b/src/content/docs/power/overview.md
@@ -1,33 +1,59 @@
 ---
-title: Power Systems
-description: How power works in an FPV quad — from battery to components.
+title: Power System
+description: Batteries, power distribution, and voltage regulation — keeping your quad in the air.
 ---
 
-The power system is the lifeblood of your quad. It delivers energy from the battery to every component — motors, flight controller, VTX, camera, receiver, and LEDs.
+The power system handles everything from storing energy to delivering it cleanly to every component on your quad. It's the foundation that everything else depends on. A bad power system causes issues that look like problems with other components: video noise, FC brownouts, motor desyncs, and random failsafes.
+
+## Components
+
+### [Battery (LiPo)](/power/battery/)
+Lithium Polymer batteries are the energy source for FPV quads. They're chosen for their high discharge rate (they can dump a lot of current quickly) and favorable power-to-weight ratio. LiPo batteries are described by cell count (S), capacity (mAh), and discharge rate (C).
+
+Common configurations:
+- **4S (14.8V nominal)**: Standard for budget builds, lighter quads, and beginners
+- **6S (22.2V nominal)**: Current standard for 5" freestyle and racing. Lower current draw for the same power output means cooler ESCs and motors.
+- **1S (3.7V)**: Tiny Whoops and micro quads
+- **2S (7.4V)**: Some micro builds and toothpick quads
+
+### [Power Distribution](/power/pdb/)
+Power from the battery needs to reach four ESCs, the flight controller, the VTX, the camera, and any other accessories. On modern builds, the 4-in-1 ESC handles most power distribution, with the FC providing regulated voltage outputs (5V, 9V) for accessories.
+
+### [Voltage Regulators](/power/regulators/)
+Many components can't handle raw battery voltage. The flight controller, VTX, and camera typically need 5V or 9V. BECs (Battery Eliminator Circuits) built into the FC or ESC step down the battery voltage. External regulators are sometimes added for high-draw accessories or to isolate noisy components.
+
+### [Charging](/power/charging/)
+LiPo batteries require balanced charging with a dedicated charger. Never charge unattended. Never charge damaged or puffed batteries. A good charger (ISDT, HOTA, ToolkitRC) is a safety-critical investment.
 
 ## Key Concepts
 
-- **Voltage (V)** — The "pressure" of electricity. Higher voltage = more power potential.
-- **Current (A)** — The "flow" of electricity. Motors draw the most current.
-- **Capacity (mAh)** — How much energy the battery holds. More capacity = longer flights but more weight.
-- **C-Rating** — How fast a battery can safely discharge. Racing packs need high C-ratings.
+### Cell Count and Voltage
+Each LiPo cell has a nominal voltage of 3.7V and a full charge of 4.2V. Cells are connected in series to increase voltage:
 
-## Power Path
+| Config | Nominal | Full Charge | Storage | Min Safe |
+|--------|---------|-------------|---------|----------|
+| 1S | 3.7V | 4.2V | 3.85V | 3.5V |
+| 4S | 14.8V | 16.8V | 15.4V | 14.0V |
+| 6S | 22.2V | 25.2V | 23.1V | 21.0V |
 
-```
-Battery → Power Distribution Board (PDB) → ESCs → Motors
-                                        → Flight Controller
-                                        → VTX (via regulator)
-                                        → Camera
-                                        → Receiver
-                                        → LEDs
-```
+Never discharge below 3.5V per cell under load. Consistently deep-discharging batteries shortens their lifespan dramatically.
 
-## Sections
+### C Rating and Current Draw
+The C rating tells you the maximum safe continuous discharge rate. A 1500mAh 100C battery can theoretically deliver 150A continuously. In practice, C ratings are often inflated by manufacturers. Buy from reputable brands (CNHL, Tattu, GNB, RDQ) and don't trust marketing numbers over real-world reviews.
 
-- [Serial vs. Parallel](/power/serial-vs-parallel/) — How batteries connect
-- [Power Distribution Board](/power/pdb/) — Splitting power to all components
-- [Regulators](/power/regulators/) — Stepping voltage down for sensitive components
-- [Battery](/power/battery/) — LiPo packs, cell counts, and what to buy
-- [Charging](/power/charging/) — Safe charging practices
-- [LEDs](/power/leds/) — Lighting up your quad
+### [Serial vs. Parallel Charging](/power/serial-vs-parallel/)
+Parallel charging lets you charge multiple same-voltage batteries simultaneously, saving time. It requires a parallel charging board and careful matching of battery voltages before connecting. Done correctly, it's a significant time saver. Done carelessly, it's a fire risk.
+
+### [LEDs](/power/leds/)
+Programmable LED strips (WS2812B) add visibility and style. They draw power from a 5V pad and receive data over a signal wire from the FC. Betaflight supports various LED patterns and can tie colors to flight mode, warnings, or other telemetry.
+
+## [Battery Safety](/safety/lipo-safety/)
+
+LiPo batteries store significant energy and can catch fire if mishandled. Essential safety practices:
+- **Charge in a fireproof bag or container**, never unattended
+- **Inspect before every charge**: Puffed, dented, or punctured batteries get retired
+- **Store at storage voltage** (3.85V/cell) when not flying within 24 hours
+- **Dispose properly**: Discharge fully into saltwater, then recycle at a battery drop-off
+- **Never charge immediately after flying**: Let batteries cool to room temperature first (15-20 minutes minimum)
+
+A LiPo fire burns hot, fast, and is difficult to extinguish. A $15 fireproof charging bag and basic discipline prevent house fires.

--- a/src/content/docs/recording/overview.md
+++ b/src/content/docs/recording/overview.md
@@ -3,13 +3,58 @@ title: Recording
 description: Capture and share your FPV flights.
 ---
 
-There are two main ways to record FPV footage — each serves a different purpose.
+Recording your FPV flights lets you review your flying, share footage with others, and document your progress. Most pilots end up using two separate recording methods, each suited to a different purpose.
 
 ## DVR vs. HD Recording
 
-- **[DVR (Digital Video Recording)](/recording/dvr/)** — Records exactly what you see in your goggles. Low quality but captures the full FPV experience including OSD.
-- **[HD Recording](/recording/hd-recording/)** — Action camera mounted on top of the quad. High quality footage for edits, YouTube, and social media.
+- **[DVR (Digital Video Recording)](/recording/dvr/)** records exactly what you see in your goggles, including the OSD overlay with battery voltage, RSSI, flight time, and other telemetry. Resolution is low (typically 720p or less for analog systems), but DVR captures the raw FPV experience.
+- **[HD Recording](/recording/hd-recording/)** uses a dedicated action camera mounted on the quad. This produces high-resolution footage (4K/120fps on modern cameras) suitable for YouTube, social media, and cinematic edits.
 
-## Why Both?
+## Why Use Both?
 
-DVR is your flight log — review crashes, analyze lines, relive flights. HD recording is your creative output — the cinematic footage you share with the world.
+DVR is your flight log. When you crash and can't find your quad, DVR footage shows exactly where you went down. When you nail a new trick, DVR shows the timing and stick feel from your perspective. When your video cuts out mid-flight, DVR tells you whether it was interference, antenna placement, or a VTX failure.
+
+HD recording is your creative output. Smooth stabilized footage from a GoPro or similar camera is what makes FPV content look professional. Raw FPV goggle footage rarely translates well to viewers who aren't pilots themselves.
+
+## Recording Equipment
+
+### DVR Options
+- **Built-in goggle DVR**: Most modern goggles (DJI, HDZero, Walksnail, even budget analog boxes) have built-in DVR recording to a microSD card. This is the simplest option.
+- **External DVR module**: For goggles without built-in recording, standalone DVR modules connect to the AV output. The Eachine ProDVR is a common budget choice.
+- **Ground station recording**: If you run a ground station setup with a monitor, you can record via a capture card to a laptop.
+
+### HD Cameras
+Popular choices for FPV:
+- **GoPro Hero series**: The industry standard. Heavy but excellent stabilization and image quality. GoPro Hero 11/12/13 Mini versions save weight.
+- **DJI Action cameras**: Competitive image quality, lighter than full-size GoPros.
+- **Insta360 Go**: Ultra-lightweight option for micro and sub-250g builds.
+- **Runcam Thumb Pro**: Budget-friendly, lightweight, decent quality for the price.
+- **Naked GoPro**: A GoPro stripped of its case and battery, powered directly from the quad's battery. Saves 100g+ but requires soldering and a BEC. Popular for freestyle builds where weight matters.
+
+## Storage
+
+MicroSD cards fill up fast when recording 4K video. A few practical notes:
+
+- **Capacity**: 64GB holds roughly 1-2 hours of 4K footage depending on bitrate. Carry multiple cards or use 128GB+.
+- **Speed**: Use cards rated V30 or UHS-I U3 minimum for 4K recording. Slow cards cause dropped frames or failed recordings.
+- **Backup habit**: Copy footage off your cards after every session. Cards fail, get lost, or get formatted accidentally.
+
+## Post-Flight Workflow
+
+A typical recording workflow:
+
+1. **Copy DVR and HD footage** to your computer after each session
+2. **Review DVR** to identify your best lines, crashes worth analyzing, and moments worth editing
+3. **Match DVR to HD clips** since they cover the same flights from different perspectives
+4. **Edit in your preferred software** (DaVinci Resolve is free and powerful, CapCut works for quick social media cuts)
+5. **Add music, color grade, and export** for your target platform
+
+## Sharing Your Footage
+
+FPV content lives across several platforms:
+- **YouTube**: Long-form edits, tutorials, build videos
+- **Instagram Reels / TikTok**: Short clips, tricks, scenic flights
+- **FPV-specific communities**: r/fpv, RCGroups, FPV Facebook groups
+- **Local flying groups**: Share with your crew for feedback and hype
+
+The FPV community is generally supportive of new pilots posting footage. Don't wait until your flying is perfect to start sharing.

--- a/src/content/docs/tools/overview.md
+++ b/src/content/docs/tools/overview.md
@@ -1,38 +1,86 @@
 ---
 title: Tools
-description: Essential tools for building and maintaining FPV quads.
+description: Essential tools for building, repairing, and maintaining FPV quads.
 ---
 
-You don't need a full workshop, but having the right tools makes building and repairing much easier.
+You need tools to build and maintain an FPV quad. The good news is the list isn't long, and most of what you need is affordable. Start with the essentials and add specialized tools as you need them.
 
 ## Essential Tools
 
 ### Soldering Iron
+The single most important tool. Every electrical connection on your quad is soldered. Get a temperature-controlled iron with at least 60W of power. Cheap irons that can't hold temperature make soldering miserable and produce bad joints.
 
-A temperature-controlled soldering iron is the single most important tool. You'll solder almost every connection on your quad. Get a decent one — a cheap iron will make your life miserable.
+Recommended options:
+- **Pinecil / TS101**: Portable, USB-C powered, excellent for field repairs. $25-40.
+- **Hakko FX-888D**: The workshop standard. Reliable, good thermal recovery. ~$100.
+- **Budget**: Any temperature-controlled station from a name brand. Avoid unregulated irons from generic sellers.
+
+Use a chisel tip (not conical) for most FPV work. Chisel tips transfer heat faster because of the flat contact area. 2mm-3mm width handles everything from FC pads to XT60 connectors.
 
 ### Solder
+60/40 or 63/37 tin/lead rosin core, 0.8mm diameter. Leaded solder flows better and is easier to work with than lead-free. Kester 0.8mm (0.031") rosin core is a popular choice among builders.
 
-Kester 0.80mm (0.31") Rosin Core is a popular choice in the FPV community. Leaded solder (63/37) flows better than lead-free. Use in a ventilated area.
+Work in a ventilated area or use a fume extractor. Rosin flux fumes are irritating over long sessions.
 
-### Hex Wrenches
+### Hex Drivers
+Most quad hardware uses hex (Allen) bolts:
+- **2.0mm**: The most common size. Motor bolts, frame bolts, standoffs.
+- **2.5mm**: Some frame hardware and prop nuts.
+- **1.5mm**: Smaller micro quad hardware, some camera mount bolts.
 
-- **2.0mm** — The most common size for miniquad screws.
-- **2.5mm** — Also prominent, especially on larger components.
-- **1.5mm** — Common on smaller quads (3" prop, 110-150mm frames).
-- A multi-tool with all three sizes is handy in the field.
+Ball-end hex drivers let you reach bolts at slight angles, which helps in tight builds. A multi-tool with all three sizes is convenient for the field.
 
-### Double-Sided Tape
+### Wire Cutters (Flush Cut)
+Flush-cut side cutters for trimming solder joints, cutting wire, and trimming zip ties. Get a pair with a fine tip for working in tight spaces around the FC stack.
 
-VHB (Very-High Bond) tape is used to mount components like receivers, VTXs, and capacitors. Strong, vibration-resistant, and easy to work with.
+### Wire Strippers
+For preparing wire ends before soldering. Adjustable strippers work on the range of wire gauges you'll encounter (26-12 AWG).
 
-### Other Essentials
+### Multimeter
+Essential for safety checks before first power-up:
+- **Continuity mode**: Check for shorts between positive and negative battery pads
+- **Voltage mode**: Verify regulator outputs (5V, 9V)
+- **Resistance mode**: Diagnose bad connections
 
-- **Wire strippers** — For prepping wires.
-- **Flush cutters** — For trimming leads and zip ties.
-- **Heat shrink tubing** — Insulate solder joints and protect wires.
-- **Zip ties** — Hold everything together.
-- **Multimeter** — Check continuity, voltage, and shorts before powering up.
-- **Smoke stopper** — A current limiter that prevents magic smoke on first power-up. Highly recommended.
-- **Helping hands / PCB holder** — Holds boards while you solder.
-- **Isopropyl alcohol** — Clean flux residue.
+Any basic multimeter works. You don't need an expensive one for FPV use.
+
+## Very Helpful Tools
+
+### Helping Hands / PCB Holder
+Holds your FC or ESC in place while you solder. Frees up both hands for iron and solder. A weighted-base helping hands with alligator clips, or a PCB vise, makes soldering dramatically easier.
+
+### Heat Gun
+For heat shrink tubing and removing old components. A basic craft heat gun ($15-25) works. A hair dryer is not hot enough for most heat shrink.
+
+### Smoke Stopper
+A current-limiting device (essentially a light bulb in series with your battery lead) that prevents damage if there's a wiring mistake on first power-up. The bulb limits current so that a short circuit lights the bulb instead of frying your electronics. Build one for $5 or buy a pre-made one for $10-15. Saves $40+ FC replacements.
+
+### Prop Removal Tool / Nut Driver
+An 8mm nut driver or socket for prop nuts. Makes prop changes fast in the field. Some pilots use a small wrench but a nut driver is faster.
+
+### Digital Calipers
+For measuring motor shaft sizes, frame dimensions, standoff lengths, and verifying part compatibility before a build. A $15 digital caliper from any hardware store works fine.
+
+## Field Kit
+
+What to bring to the flying field:
+- Hex driver set (2.0mm, 2.5mm, 1.5mm)
+- Spare props and prop nut tool
+- Zip ties and electrical tape
+- Small flush cutters
+- Spare receiver antenna (they break)
+- Battery voltage checker or multimeter
+- Small bag of spare bolts and nuts (M3 assorted)
+
+Keep a small tool bag packed and ready. Repacking tools after every session is a habit worth building.
+
+## Workshop Additions
+
+As you do more builds:
+- **Desoldering wick or pump**: For fixing mistakes and replacing components
+- **Flux pen**: Extra flux makes difficult joints (large ground pads, XT60 connectors) flow much better
+- **Silicone wire**: 12-16 AWG silicone-insulated wire for battery leads and high-current connections. More flexible than PVC-insulated wire.
+- **Bench power supply**: Powers your quad without a battery for bench testing. Limits current so mistakes don't destroy components.
+- **Label maker or fine-point marker**: Label motor positions, receiver channels, and custom wiring so future-you can figure out what past-you did.
+
+See the [accessories guide](/tools/accessories/) for specific product recommendations.


### PR DESCRIPTION
Every page that was under 250 words has been expanded to 500-900 words of practical, beginner-friendly content.

## Pages expanded (16 total)
- **Getting Started**: introduction, anatomy
- **Drive System**: overview, brushed-vs-brushless, pwm-signal
- **Frame**: overview, micro, miniquad
- **Control**: overview, protocols
- **FPV Video**: overview
- **Power**: overview
- **Building**: overview
- **Flight School**: overview
- **Recording**: overview
- **Tools**: overview

## What changed
- Added real technical content with practical advice
- Comparison tables for protocols, frame sizes, motor specs
- Beginner-friendly explanations without dumbing things down
- Cross-links between related pages
- No filler, all actionable information

Total: +994 lines, -255 lines across 16 files.